### PR TITLE
VICE.js support

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -181,7 +181,6 @@ var Module = null;
                                            if ('keepAspect' in cfgr) {
                                              cfgr.keepAspect(modulecfg.keepAspect);
                                            }
-                                           console.log("modulecfg", modulecfg);
 
                                            if (/archive\.org$/.test(document.location.hostname)) {
                                              cfgr.muted(!(typeof $ !== 'undefined' && $.cookie && $.cookie('unmute')));
@@ -226,7 +225,6 @@ var Module = null;
                                            resolve(cfgr.apply(null, extend(config_args, game_files)));
                                          },
                                          function (e) {
-                                           console.log(e);
                                            if (splash.failed_loading) {
                                              return;
                                            }
@@ -609,7 +607,6 @@ var Module = null;
     */
     function VICELoader() {
       var config = Array.prototype.reduce.call(arguments, extend);
-      console.log("VICELoader config", config);
       config.emulator_arguments = build_vice_arguments(config.emulatorStart, config.files, config.extra_vice_args);
       config.runner = EmscriptenRunner;
       return config;
@@ -736,7 +733,6 @@ var Module = null;
        if(extra_args) {
            args = args.concat(extra_args);
        }
-       console.log("build_vice_arguments result", args);
        return args;
    }
 
@@ -749,7 +745,6 @@ var Module = null;
      // This is somewhat wrong, because our Emscripten-based emulators
      // are currently compiled to start immediately when their js file
      // is loaded.
-     console.log("arguments:", game_data.emulator_arguments);
      Module = { arguments: game_data.emulator_arguments,
                 screenIsReadOnly: true,
                 print: function (text) { console.log(text); },

--- a/loader.js
+++ b/loader.js
@@ -564,6 +564,15 @@ var Module = null;
    MAMELoader.extraArgs = function (args) {
      return { extra_mame_args: args };
    };
+   
+   /**
+    * VICELoader
+    */
+    function VICELoader() {
+      var config = Array.prototype.reduce.call(arguments, extend);
+      config.runner = VICERunner;
+    }
+    VICELoader.__proto__ = BaseLoader;
 
    /**
     * SAELoader

--- a/loader.js
+++ b/loader.js
@@ -154,6 +154,11 @@ var Module = null;
                                              cfgr = PCELoader;
                                              get_files = get_pce_files;
                                            }
+                                           else if (module && module.indexOf("vice-") === 0) {
+                                             emulator_logo = images.ia; // TODO: Use VICE or C64 logo
+                                             cfgr = VICELoader;
+                                             get_files = get_vice_files;
+                                           }
                                            else if (module) {
                                              emulator_logo = images.mame;
                                              cfgr = MAMELoader;

--- a/loader.js
+++ b/loader.js
@@ -194,7 +194,6 @@ var Module = null;
                                              config_args.push(cfgr.autoLoad(metadata.getElementsByTagName("emulator_start")
                                                                                     .item(0)
                                                                                     .textContent));
-                                           }
                                            } else if (module && module.indexOf("sae-") === 0) {
                                              config_args.push(cfgr.model(modulecfg.driver),
                                                               cfgr.rom(modulecfg.bios_filenames));
@@ -223,7 +222,8 @@ var Module = null;
                                            updateLogo();
                                            resolve(cfgr.apply(null, extend(config_args, game_files)));
                                          },
-                                         function () {
+                                         function (e) {
+                                           console.log(e);
                                            if (splash.failed_loading) {
                                              return;
                                            }
@@ -275,29 +275,30 @@ var Module = null;
      
      function get_vice_files(cfgr, metadata, modulecfg, filelist) {
        var default_drive = "8", 
-           drives = {}, files = [],
+           drives = {}, files = [], wanted_files = []
            meta = dict_from_xml(metadata);
        files_with_ext_from_filelist(filelist, meta.emulator_ext).forEach(function (file, i) {
-                                                                           drives[default_drive] = file.name;
+                                                                           //drives[default_drive] = file.name;
+                                                                           wanted_files.push(file.name);
                                                                          });
        meta_props_matching(meta, /^vice_drive_([89])$/).forEach(function (result) {
                                                                         let key = result[0], match = result[1];
                                                                         drives[match[1]] = meta[key];
                                                                       });
-       var mounts = Object.keys(drives),
-           len = mounts.length;
-       mounts.forEach(function (drive, i) {
+       var len = wanted_files.length;
+       wanted_files.forEach(function (file, i) {
                         var title = "Game File ("+ (i+1) +" of "+ len +")",
-                            filename = drives[drive],
+                            filename = file,
                             url = (filename.includes("/")) ? get_zip_url(filename)
                                                            : get_zip_url(filename, get_item_name(game));
-                            if (filename.toLowerCase().endsWith(".zip")) {
-                              files.push(cfgr.mountZip(drive,
-                                                       cfgr.fetchFile(title, url)));
-                            } else {
+                            //if (filename.toLowerCase().endsWith(".zip")) {
+                            //  files.push(cfgr.mountZip(drive,
+                            //                           cfgr.fetchFile(title, url)));
+                            //} else {
+                            // TODO: ensure vice_drive_8 and vice_drive_9 actually function.
                               files.push(cfgr.mountFile('/'+ filename,
                                                         cfgr.fetchFile(title, url)));
-                            }
+                            //}
                       });
        return files;
      }
@@ -604,7 +605,9 @@ var Module = null;
     */
     function VICELoader() {
       var config = Array.prototype.reduce.call(arguments, extend);
-      config.runner = VICERunner;
+      config.emulator_arguments = build_vice_arguments(config.emulatorStart, config.files, config.extra_dosbox_args);
+      config.runner = EmscriptenRunner;
+      return config;
     }
     VICELoader.__proto__ = BaseLoader;
     
@@ -719,6 +722,14 @@ var Module = null;
 
      return args;
    };
+   
+   var build_vice_arguments = function (emulator_start, files, extra_args) {
+       var args = ["/emulator/" + emulator_start];
+       if(extra_args) {
+           args.append(extra_args);
+       }
+       return args;
+   }
 
    /*
     * EmscriptenRunner
@@ -729,6 +740,7 @@ var Module = null;
      // This is somewhat wrong, because our Emscripten-based emulators
      // are currently compiled to start immediately when their js file
      // is loaded.
+     console.log("arguments:", game_data.emulator_arguments);
      Module = { arguments: game_data.emulator_arguments,
                 screenIsReadOnly: true,
                 print: function (text) { console.log(text); },

--- a/loader.js
+++ b/loader.js
@@ -181,6 +181,7 @@ var Module = null;
                                            if ('keepAspect' in cfgr) {
                                              cfgr.keepAspect(modulecfg.keepAspect);
                                            }
+                                           console.log("modulecfg", modulecfg);
 
                                            if (/archive\.org$/.test(document.location.hostname)) {
                                              cfgr.muted(!(typeof $ !== 'undefined' && $.cookie && $.cookie('unmute')));
@@ -191,9 +192,11 @@ var Module = null;
                                                                                     .item(0)
                                                                                     .textContent));
                                            } else if (module && module.indexOf("vice-") === 0) {
-                                             config_args.push(cfgr.autoLoad(metadata.getElementsByTagName("emulator_start")
-                                                                                    .item(0)
-                                                                                    .textContent));
+                                             let emulator_start_item = metadata.getElementsByTagName("emulator_start").item(0);
+                                             if (emulator_start_item) {
+                                               config_args.push(cfgr.autoLoad(emulator_start_item.textContent));
+                                             }
+                                             config_args.push(cfgr.extraArgs(modulecfg.extra_args));
                                            } else if (module && module.indexOf("sae-") === 0) {
                                              config_args.push(cfgr.model(modulecfg.driver),
                                                               cfgr.rom(modulecfg.bios_filenames));
@@ -605,7 +608,8 @@ var Module = null;
     */
     function VICELoader() {
       var config = Array.prototype.reduce.call(arguments, extend);
-      config.emulator_arguments = build_vice_arguments(config.emulatorStart, config.files, config.extra_dosbox_args);
+      console.log("VICELoader config", config);
+      config.emulator_arguments = build_vice_arguments(config.emulatorStart, config.files, config.extra_vice_args);
       config.runner = EmscriptenRunner;
       return config;
     }
@@ -613,7 +617,10 @@ var Module = null;
     
     VICELoader.autoLoad = function (path) {
      return { emulatorStart: path };
-   };
+    };
+    VICELoader.extraArgs = function (args) {
+      return { extra_vice_args: args };
+    }
 
    /**
     * SAELoader
@@ -724,10 +731,11 @@ var Module = null;
    };
    
    var build_vice_arguments = function (emulator_start, files, extra_args) {
-       var args = ["/emulator/" + emulator_start];
+       var args = emulator_start ? ["-autostart", "/emulator/" + emulator_start] : [];
        if(extra_args) {
-           args.append(extra_args);
+           args = args.concat(extra_args);
        }
+       console.log("build_vice_arguments result", args);
        return args;
    }
 

--- a/loader.js
+++ b/loader.js
@@ -154,7 +154,7 @@ var Module = null;
                                              cfgr = PCELoader;
                                              get_files = get_pce_files;
                                            }
-                                           else if (module && module.indexOf("vice-") === 0) {
+                                           else if (module && module.indexOf("vice") === 0) {
                                              emulator_logo = images.ia; // TODO: Use VICE or C64 logo
                                              cfgr = VICELoader;
                                              get_files = get_vice_files;
@@ -191,7 +191,7 @@ var Module = null;
                                              config_args.push(cfgr.startExe(metadata.getElementsByTagName("emulator_start")
                                                                                     .item(0)
                                                                                     .textContent));
-                                           } else if (module && module.indexOf("vice-") === 0) {
+                                           } else if (module && module.indexOf("vice") === 0) {
                                              let emulator_start_item = metadata.getElementsByTagName("emulator_start").item(0);
                                              if (emulator_start_item) {
                                                config_args.push(cfgr.autoLoad(emulator_start_item.textContent));

--- a/loader.js
+++ b/loader.js
@@ -294,14 +294,15 @@ var Module = null;
                             filename = file,
                             url = (filename.includes("/")) ? get_zip_url(filename)
                                                            : get_zip_url(filename, get_item_name(game));
-                            //if (filename.toLowerCase().endsWith(".zip")) {
-                            //  files.push(cfgr.mountZip(drive,
-                            //                           cfgr.fetchFile(title, url)));
-                            //} else {
-                            // TODO: ensure vice_drive_8 and vice_drive_9 actually function.
+                            console.log("Retrieving URL",url);
+                            if (filename.toLowerCase().endsWith(".zip")&&false) { // TODO: Enable and fix zip support.
+                              files.push(cfgr.mountZip("", // TODO: This is a hack, no drive actually applicable here
+                                                       cfgr.fetchFile(title, url)));
+                            } else {
+                             //TODO: ensure vice_drive_8 and vice_drive_9 actually function.
                               files.push(cfgr.mountFile('/'+ filename,
                                                         cfgr.fetchFile(title, url)));
-                            //}
+                            }
                       });
        return files;
      }

--- a/vice_todo.txt
+++ b/vice_todo.txt
@@ -1,5 +1,5 @@
 * Add logo
-* Define get_vice_files: This is where to add support for metadata entries (ala dosbox_drive_d)
+* Define get_vice_files: This is where to add support for metadata entries (ala dosbox_drive_d) [done, imperfectly]
 * Define VICELoader
 * Define VICERunner
 * Add entry in config_args push area (don't fall through to MAME)

--- a/vice_todo.txt
+++ b/vice_todo.txt
@@ -1,3 +1,7 @@
 * Add logo
-* Define get_vice_files
+* Define get_vice_files: This is where to add support for metadata entries (ala dosbox_drive_d)
 * Define VICELoader
+* Define VICERunner
+* Add entry in config_args push area (don't fall through to MAME)
+* Check if "this is a stupid hack" applies to VICE
+* Useful hardcoded IA entries: https://archive.org/details/emularity_engine_v1 

--- a/vice_todo.txt
+++ b/vice_todo.txt
@@ -1,0 +1,3 @@
+* Add logo
+* Define get_vice_files
+* Define VICELoader


### PR DESCRIPTION
Support VICE.js

Features:
* Can autoload files with `emulator_start`, or by omitting that metadata, boot into BASIC

Known missing features:
* Mounting d64 without loading
* Fliplists for multiple disks on one drive and switching between then
* Config files.
* Joystick emulation
* Mute button support