### PR TITLE
Add DOSBox-X support for PC-98 emulation

### DIFF
--- a/example_pc98dosbox.html
+++ b/example_pc98dosbox.html
@@ -10,14 +10,19 @@
    are required. The logo and images directories are optional, but the
    splash screen looks quite a lot better when they're available.
 
- * Download the two files that comprise the compiled DosBox emulator:
-   https://archive.org/download/emularity_engine_v1/dosbox-sync.js.gz,
-   and https://archive.org/download/emularity_engine_v1/dosbox-sync.mem.gz.
+ * Download the files that comprise the compiled DosBox-X (PC-9821) emulator:
+   http://jsemu.oss-cn-shanghai.aliyuncs.com/pc98dosbox/dosbox-x.js,
+   and http://jsemu.oss-cn-shanghai.aliyuncs.com/pc98dosbox/dosbox-x.wasm.
 
- * Download a copy of Doom from https://archive.org/download/DoomsharewareEpisode/DoomV1.9sw1995idSoftwareInc.action.zip
+ * Download a package of Japanese fonts file, YM2608 sound samples and default dosbox.conf
+   http://jsemu.oss-cn-shanghai.aliyuncs.com/pc98dosbox/font.zip
 
- * Visit your example_dosbox.html file with a modern
+ * Download a copy of Touhou Reiiden from http://jsemu.oss-cn-shanghai.aliyuncs.com/pc98dosbox/th1.zip
+
+ * Visit your example_pc98dosbox.html file with a modern
    Javascript-capable browser.
+
+ * For more information about the DOSBox-X Emscripten port, please see https://yksoft1.github.io/dosboxxem-demo/
 -->
 
 <html>
@@ -40,7 +45,7 @@
 
           PC98DosBoxLoader.mountZip("c",
             PC98DosBoxLoader.fetchFile("Game File",
-              "examples/th02.zip")),
+              "examples/th1.zip")),
           PC98DosBoxLoader.mountZip("y",
             PC98DosBoxLoader.fetchFile("ROM File",
               "examples/font.zip")),

--- a/example_pc98dosbox.html
+++ b/example_pc98dosbox.html
@@ -42,7 +42,12 @@
           PC98DosBoxLoader.emulatorWASM("emulators/dosbox-x/dosbox.wasm"),
           PC98DosBoxLoader.locateAdditionalEmulatorJS(locateAdditionalFiles),
           PC98DosBoxLoader.nativeResolution(640, 480),
-
+          /* DOSBox-X seems like always need a doxbox.conf to run in PC-98 mode correctly, load your dosbox.conf
+             when it is not include in your game package
+          PC98DosBoxLoader.mountFile("dosbox.conf",
+            PC98DosBoxLoader.fetchFile("Configuration File",
+              "dosbox.conf")),
+          */
           PC98DosBoxLoader.mountZip("c",
             PC98DosBoxLoader.fetchFile("Game File",
               "examples/th1.zip")),

--- a/example_pc98dosbox.html
+++ b/example_pc98dosbox.html
@@ -1,0 +1,59 @@
+<!--
+ The Emularity: An Example Computer Loader
+ For use with The Emularity, downloadable at http://www.emularity.com/
+
+ SIMPLE STEPS for trying an emulated computer ("Doom (shareware
+ edition)" for the PC).
+
+ * Check out this repository in your browser-accessible directory;
+   this file as well as es6-promise.js, browserfs.min.js and loader.js
+   are required. The logo and images directories are optional, but the
+   splash screen looks quite a lot better when they're available.
+
+ * Download the two files that comprise the compiled DosBox emulator:
+   https://archive.org/download/emularity_engine_v1/dosbox-sync.js.gz,
+   and https://archive.org/download/emularity_engine_v1/dosbox-sync.mem.gz.
+
+ * Download a copy of Doom from https://archive.org/download/DoomsharewareEpisode/DoomV1.9sw1995idSoftwareInc.action.zip
+
+ * Visit your example_dosbox.html file with a modern
+   Javascript-capable browser.
+-->
+
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>example dos game</title>
+  </head>
+  <body>
+    <canvas id="canvas" style="width: 50%; height: 50%; display: block; margin: 0 auto;"/>
+    <script type="text/javascript" src="es6-promise.js"></script>
+    <script type="text/javascript" src="browserfs.min.js"></script>
+    <script type="text/javascript" src="loader.js"></script>
+    <script type="text/javascript">
+      var emulator = new Emulator(document.querySelector("#canvas"),
+        null,
+        new PC98DosBoxLoader(PC98DosBoxLoader.emulatorJS("emulators/dosbox-x/dosbox.js"),
+          PC98DosBoxLoader.emulatorWASM("emulators/dosbox-x/dosbox.wasm"),
+          PC98DosBoxLoader.locateAdditionalEmulatorJS(locateAdditionalFiles),
+          PC98DosBoxLoader.nativeResolution(640, 480),
+
+          PC98DosBoxLoader.mountZip("c",
+            PC98DosBoxLoader.fetchFile("Game File",
+              "examples/th02.zip")),
+          PC98DosBoxLoader.mountZip("y",
+            PC98DosBoxLoader.fetchFile("ROM File",
+              "examples/font.zip")),
+
+          PC98DosBoxLoader.startExe("game.bat")))
+      emulator.start({ waitAfterDownloading: true });
+
+      function locateAdditionalFiles(filename) {
+        if (filename === "dosbox.html.mem") {
+          return "emulators/em-dosbox/dosbox-sync.mem";
+        }
+        return "emulators/dosbox-x/"+ filename;
+      }
+    </script>
+  </body>
+</html>

--- a/loader.js
+++ b/loader.js
@@ -842,7 +842,6 @@ var Module = null;
   }
   PC98DosBoxRunner.prototype = Object.create(EmscriptenRunner.prototype);
   PC98DosBoxRunner.prototype.start = function () {
-    FS.symlink('/emulator/y/dosbox-default.conf', '/dosbox.conf');
     FS.symlink('/emulator/y/FONT.ROM', '/FONT.ROM');
     FS.symlink('/emulator/y/2608_bd.wav', '/2608_bd.wav');
     FS.symlink('/emulator/y/2608_hh.wav', '/2608_hh.wav');
@@ -1290,7 +1289,7 @@ var Module = null;
                       }
 
                       if ("runner" in game_data) {
-                        if (game_data.runner == EmscriptenRunner || game_data.runner == MAMERunner || game_data.runner == PC98DosBoxRunner) {
+                        if (game_data.runner == EmscriptenRunner || game_data.runner.prototype instanceof EmscriptenRunner) {
                           // this is a stupid hack. Emscripten-based
                           // apps currently need the runner to be set
                           // up first, then we can attach the

--- a/loader.js
+++ b/loader.js
@@ -842,13 +842,14 @@ var Module = null;
   }
   PC98DosBoxRunner.prototype = Object.create(EmscriptenRunner.prototype);
   PC98DosBoxRunner.prototype.start = function () {
-    FS.symlink('./emulator/y/FONT.ROM', '/FONT.ROM');
-    FS.symlink('./emulator/y/2608_bd.wav', '/2608_bd.wav');
-    FS.symlink('./emulator/y/2608_hh.wav', '/2608_hh.wav');
-    FS.symlink('./emulator/y/2608_sd.wav', '/2608_sd.wav');
-    FS.symlink('./emulator/y/2608_rim.wav', '/2608_rim.wav');
-    FS.symlink('./emulator/y/2608_tom.wav', '/2608_tom.wav');
-    FS.symlink('./emulator/y/2608_top.wav', '/2608_top.wav');
+    FS.symlink('/emulator/y/dosbox-default.conf', '/dosbox.conf');
+    FS.symlink('/emulator/y/FONT.ROM', '/FONT.ROM');
+    FS.symlink('/emulator/y/2608_bd.wav', '/2608_bd.wav');
+    FS.symlink('/emulator/y/2608_hh.wav', '/2608_hh.wav');
+    FS.symlink('/emulator/y/2608_sd.wav', '/2608_sd.wav');
+    FS.symlink('/emulator/y/2608_rim.wav', '/2608_rim.wav');
+    FS.symlink('/emulator/y/2608_tom.wav', '/2608_tom.wav');
+    FS.symlink('/emulator/y/2608_top.wav', '/2608_top.wav');
   }
 
    /*

--- a/loader.js
+++ b/loader.js
@@ -573,6 +573,25 @@ var Module = null;
    };
 
    /**
+    * PC98DosBoxLoader
+    */
+   function PC98DosBoxLoader() {
+    var config = Array.prototype.reduce.call(arguments, extend);
+    config.emulator_arguments = build_dosbox_arguments(config.emulatorStart, config.files, config.extra_dosbox_args);
+    config.runner = PC98DosBoxRunner;
+    return config;
+  }
+  PC98DosBoxLoader.__proto__ = BaseLoader;
+
+  PC98DosBoxLoader.startExe = function (path) {
+    return { emulatorStart: path };
+  };
+
+  PC98DosBoxLoader.extraArgs = function (args) {
+    return { extra_dosbox_args: args };
+  };
+
+   /**
     * MAMELoader
     */
    function MAMELoader() {
@@ -814,6 +833,23 @@ var Module = null;
 
    EmscriptenRunner.prototype.requestFullScreen = function () {
    };
+
+   /*
+    * PC98DosBoxRunner
+    */
+  function PC98DosBoxRunner() {
+    return EmscriptenRunner.apply(this, arguments);
+  }
+  PC98DosBoxRunner.prototype = Object.create(EmscriptenRunner.prototype);
+  PC98DosBoxRunner.prototype.start = function () {
+    FS.symlink('./emulator/y/FONT.ROM', '/FONT.ROM');
+    FS.symlink('./emulator/y/2608_bd.wav', '/2608_bd.wav');
+    FS.symlink('./emulator/y/2608_hh.wav', '/2608_hh.wav');
+    FS.symlink('./emulator/y/2608_sd.wav', '/2608_sd.wav');
+    FS.symlink('./emulator/y/2608_rim.wav', '/2608_rim.wav');
+    FS.symlink('./emulator/y/2608_tom.wav', '/2608_tom.wav');
+    FS.symlink('./emulator/y/2608_top.wav', '/2608_top.wav');
+  }
 
    /*
     * MAMERunner
@@ -1253,7 +1289,7 @@ var Module = null;
                       }
 
                       if ("runner" in game_data) {
-                        if (game_data.runner == EmscriptenRunner || game_data.runner == MAMERunner) {
+                        if (game_data.runner == EmscriptenRunner || game_data.runner == MAMERunner || game_data.runner == PC98DosBoxRunner) {
                           // this is a stupid hack. Emscripten-based
                           // apps currently need the runner to be set
                           // up first, then we can attach the
@@ -1803,6 +1839,7 @@ var Module = null;
 
    window.IALoader = IALoader;
    window.DosBoxLoader = DosBoxLoader;
+   window.PC98DosBoxLoader = PC98DosBoxLoader;
    window.JSMESSLoader = MAMELoader; // depreciated; just for backwards compatibility
    window.JSMAMELoader = MAMELoader; // ditto
    window.MAMELoader = MAMELoader;


### PR DESCRIPTION
This change added DOSBox-X support to provide NEC PC-98 emulation
The original DOSBox-X Emscripten port is done by @yksoft1
https://yksoft1.github.io/dosboxxem-demo/

Here is a demo shows Touhou Project: Highly Responsive to Prayers
http://jsemu.oss-cn-shanghai.aliyuncs.com/pc98dosbox/th1.html

The FONT.ROM and YM2608 sound samples have to placed to the root directory of Emscripten, otherwise it's quite similar to EM-DOSBox