### PR TITLE
Add extraArgs support for PCE and PCE IBM PC example

### DIFF
--- a/example_pce_ibmpc.html
+++ b/example_pce_ibmpc.html
@@ -1,0 +1,65 @@
+<!--
+ The Emularity: An Example Computer Loader
+ For use with The Emularity, downloadable at http://www.emularity.com/
+
+ SIMPLE STEPS for trying an emulated computer ("PC-DOS 1.0" for the
+ IBM PC Model 5150).
+
+ * Check out this repository in your browser-accessible directory;
+   this file as well as es6-promise.js, browserfs.min.js and loader.js
+   are required. The logo and images directories are optional, but the
+   splash screen looks quite a lot better when they're available.
+
+ * Download the PCE.js IBM PC emulator from
+   https://9game.oss-us-west-1.aliyuncs.com/mini-ibmpc/pcejs-ibmpc.min.js
+   It's a slightly modified version from the NPM one:
+   https://www.npmjs.com/package/pcejs-ibmpc
+ 
+ * Download the original IBM PC BIOS package
+   https://9game.oss-us-west-1.aliyuncs.com/mini-ibmpc/rom-ibmpc-1981.zip
+
+ * Download the configuration file, it's a minimized version for easiler
+   to make your configuration based on that
+   https://9game.oss-us-west-1.aliyuncs.com/mini-ibmpc/pce-mini.cfg
+
+ * Download PC-DOS 1.0 disk image
+   https://9game.oss-us-west-1.aliyuncs.com/mini-ibmpc/pcdos1_0.pfdc
+
+ * Visit your example_computer.html file with a modern
+   Javascript-capable browser.
+-->
+
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>PCE.js IBM-PC example</title>
+</head>
+
+<body>
+  <canvas id="canvas" style="width: 50%; height: 50%; display: block; margin: 0 auto;"></canvas>
+  <script type="text/javascript" src="es6-promise.js"></script>
+  <script type="text/javascript" src="browserfs.min.js"></script>
+  <script type="text/javascript" src="loader.js"></script>
+  <script type="text/javascript">
+    var emulator = new Emulator(document.querySelector("#canvas"),
+      null,
+      new PCELoader(PCELoader.model("ibmpc"),
+        PCELoader.nativeResolution(320, 200),
+        PCELoader.mountZip("roms", PCELoader.fetchFile("ROM", "rom-ibmpc-1981.zip")),
+        PCELoader.mountFile("fd0.pfdc", PCELoader.fetchFile("Disk Image", "pcdos1_0.pfdc")),
+        PCELoader.mountFile("pce-ibmpc.cfg", PCELoader.fetchFile("PCE Config", "pce-mini.cfg")),
+        PCELoader.emulatorJS("pcejs-ibmpc.min.js"),
+        /*
+        Extra Arguments is required if you need video device other than VGA. Use "-g" argument 
+        follows video device model "mda", "cga", "hgc", "plantronics", "ega", "vga" or "wy700"
+        to select your video card model.
+        To change the emulation speed, use "-s" argument follows the speed factor, "1" for the
+        original speed of 4.77Mhz Intel 8088 processor.
+        */
+        PCELoader.extraArgs(["-g", "cga", "-s", "4"])))
+    emulator.start({ waitAfterDownloading: true });
+  </script>
+</body>
+
+</html>

--- a/loader.js
+++ b/loader.js
@@ -683,6 +683,9 @@ var Module = null;
    function PCELoader() {
      var config = Array.prototype.reduce.call(arguments, extend);
      config.emulator_arguments = ["-c", "/emulator/pce-"+ config.pceModel +".cfg"];
+     if (config.extra_pce_args && config.extra_pce_args.length > 0) {
+       config.emulator_arguments = config.emulator_arguments.concat(config.extra_pce_args);
+     }
      config.runner = EmscriptenRunner;
      return config;
    }
@@ -690,6 +693,10 @@ var Module = null;
 
    PCELoader.model = function (model) {
      return { pceModel: model };
+   };
+
+   PCELoader.extraArgs = function (args) {
+     return { extra_pce_args: args };
    };
 
    var build_mame_arguments = function (muted, driver, native_resolution, sample_rate, peripheral, extra_args, keepaspect) {


### PR DESCRIPTION
The extraArgs parameter is required to setup a PCE.js IBM-PC emulator with MDA or CGA video adapter. Low level emulation of IBM PC is useful to emulate non-DOS systems like XENIX and CP/M 86. Also added an example shows how to setup a IBM PC 5150 emulator with CGA video adapter configured by extraArgs.