### PR TITLE
Fix PC98DosBoxLoader default mount behavior problem

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -606,15 +606,7 @@ var Module = null;
     config.runner = PC98DosBoxRunner;
     return config;
   }
-  PC98DosBoxLoader.__proto__ = BaseLoader;
-
-  PC98DosBoxLoader.startExe = function (path) {
-    return { emulatorStart: path };
-  };
-
-  PC98DosBoxLoader.extraArgs = function (args) {
-    return { extra_dosbox_args: args };
-  };
+  PC98DosBoxLoader.__proto__ = DosBoxLoader;
 
    /**
     * MAMELoader


### PR DESCRIPTION
The "drive_type" option change don't have a default behavior, code based on previous versions (includes the doxbox and pc98doxbox example in this repository) won't work because they don't have a "drive_type" option specified. This change will makes the default behavior compatible with previous versions.