### PR TITLE
Add Neko Project II and X Millennium support

### DIFF
--- a/example_minivmac.html
+++ b/example_minivmac.html
@@ -1,0 +1,62 @@
+<!--
+ The Emularity: An Example Computer Loader
+ For use with The Emularity, downloadable at http://www.emularity.com/
+
+ SIMPLE STEPS for trying an emulated computer ("System 7.0.1" for the
+ Macintosh Plus).
+
+ * Check out this repository in your browser-accessible directory;
+   this file as well as es6-promise.js, browserfs.min.js and loader.js
+   are required. The logo and images directories are optional, but the
+   splash screen looks quite a lot better when they're available.
+
+ * Download the Neko Project II emulator from
+   https://yksoft1.github.io/emularity/minivmac/minivmac.js
+   https://yksoft1.github.io/emularity/minivmac/minivmac.wasm
+
+ * Download BIOS and configuration from
+   https://yksoft1.github.io/emularity/minivmac/vmac.zip
+
+ * Download the System 7.0.1 disk image from:
+   https://yksoft1.github.io/emularity/minivmac/test7.zip
+   then extract the "test7.dsk" disk image file
+
+ * Place BIOS, configuration file and disk image in an
+   "examples" subdirectory.
+
+ * Visit your example_computer.html file with a modern
+   Javascript-capable browser.
+-->
+
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>example computer program</title>
+</head>
+
+<body>
+  <canvas id="canvas" style="width: 50%; height: 50%; display: block; margin: 0 auto;" />
+  <script type="text/javascript" src="es6-promise.js"></script>
+  <script type="text/javascript" src="browserfs.min.js"></script>
+  <script type="text/javascript" src="loader.js"></script>
+  <script type="text/javascript">
+    var emulator = new Emulator(document.querySelector("#canvas"),
+      null,
+      new NP2Loader(
+        NP2Loader.nativeResolution(512, 342),
+        NP2Loader.emulatorJS("emulators/minivmac.js"),
+        NP2Loader.emulatorWASM("emulators/minivmac.wasm"),
+        NP2Loader.mountZip("minivmac",
+          NP2Loader.fetchFile("Mac ROM files",
+            "examples/vmac.zip")),
+        NP2Loader.mountFile("test7.dsk",
+          NP2Loader.fetchFile("Disk Image",
+            "examples/test7.dsk")),
+        NP2Loader.extraArgs(["/emulator/test7.dsk"])
+      ));
+    emulator.setScale(3).start({ waitAfterDownloading: true });
+  </script>
+</body>
+
+</html>

--- a/example_minivmacii.html
+++ b/example_minivmacii.html
@@ -1,0 +1,62 @@
+<!--
+ The Emularity: An Example Computer Loader
+ For use with The Emularity, downloadable at http://www.emularity.com/
+
+ SIMPLE STEPS for trying an emulated computer ("System 7.0.1" for the
+ Macintosh II).
+
+ * Check out this repository in your browser-accessible directory;
+   this file as well as es6-promise.js, browserfs.min.js and loader.js
+   are required. The logo and images directories are optional, but the
+   splash screen looks quite a lot better when they're available.
+
+ * Download the Neko Project II emulator from
+   https://yksoft1.github.io/emularity/minivmac/minivmacII.js
+   https://yksoft1.github.io/emularity/minivmac/minivmacII.wasm
+
+ * Download BIOS and configuration from
+   https://yksoft1.github.io/emularity/minivmac/macii.zip
+
+ * Download the System 7.0.1 disk image from:
+   https://yksoft1.github.io/emularity/minivmac/test7.zip
+   then extract the "test7.dsk" disk image file
+
+ * Place BIOS, configuration file and disk image in an
+   "examples" subdirectory.
+
+ * Visit your example_computer.html file with a modern
+   Javascript-capable browser.
+-->
+
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>example computer program</title>
+</head>
+
+<body>
+  <canvas id="canvas" style="width: 50%; height: 50%; display: block; margin: 0 auto;" />
+  <script type="text/javascript" src="es6-promise.js"></script>
+  <script type="text/javascript" src="browserfs.min.js"></script>
+  <script type="text/javascript" src="loader.js"></script>
+  <script type="text/javascript">
+    var emulator = new Emulator(document.querySelector("#canvas"),
+      null,
+      new NP2Loader(
+        NP2Loader.nativeResolution(640, 480),
+        NP2Loader.emulatorJS("emulators/minivmacII.js"),
+        NP2Loader.emulatorWASM("emulators/minivmacII.wasm"),
+        NP2Loader.mountZip("minivmac",
+          NP2Loader.fetchFile("Mac ROM files",
+            "examples/macii.zip")),
+        NP2Loader.mountFile("test7.dsk",
+          NP2Loader.fetchFile("Disk Image",
+            "examples/test7.dsk")),
+        NP2Loader.extraArgs(["/emulator/test7.dsk"])
+      ));
+    emulator.setScale(3).start({ waitAfterDownloading: true });
+  </script>
+</body>
+
+</html>

--- a/example_np2.html
+++ b/example_np2.html
@@ -1,0 +1,66 @@
+<!--
+ The Emularity: An Example Computer Loader
+ For use with The Emularity, downloadable at http://www.emularity.com/
+
+ SIMPLE STEPS for trying an emulated computer ("FreeDOS(98)" for the
+ PC9801).
+
+ * Check out this repository in your browser-accessible directory;
+   this file as well as es6-promise.js, browserfs.min.js and loader.js
+   are required. The logo and images directories are optional, but the
+   splash screen looks quite a lot better when they're available.
+
+ * Download the Neko Project II emulator from
+   https://yksoft1.github.io/emularity/np2/np2-386.js
+   https://yksoft1.github.io/emularity/np2/np2-386.wasm
+
+ * Download BIOS and sound samples from
+   http://9game.oss-us-west-1.aliyuncs.com/np2/np2roms.zip
+
+ * Download the config file for the Neko Project II from
+   http://9game.oss-us-west-1.aliyuncs.com/np2/np2.cfg
+
+ * Download the FreeDOS(98) HDD image from:
+   http://9game.oss-us-west-1.aliyuncs.com/np2/FreeDOS98_5M.zip
+
+ * Place BIOS, configuration file and unzipped disk image
+   "FreeDOS(98)_5M.NHD" in the "examples/np2" subdirectory.
+
+ * Visit your example_computer.html file with a modern
+   Javascript-capable browser.
+-->
+
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>example computer program</title>
+</head>
+
+<body>
+  <canvas id="canvas" style="width: 50%; height: 50%; display: block; margin: 0 auto;" />
+  <script type="text/javascript" src="es6-promise.js"></script>
+  <script type="text/javascript" src="browserfs.min.js"></script>
+  <script type="text/javascript" src="loader.js"></script>
+  <script type="text/javascript">
+    var emulator = new Emulator(document.querySelector("#canvas"),
+      null,
+      new NP2Loader(
+        NP2Loader.nativeResolution(640, 400),
+        NP2Loader.emulatorJS("emulators/np2-386.js"),
+        NP2Loader.emulatorWASM("emulators/np2-386.wasm"),
+        NP2Loader.mountZip("np2",
+          NP2Loader.fetchFile("Bios",
+            "examples/np2/np2roms.zip")),
+        NP2Loader.mountFile("FreeDOS(98)_5M.NHD",
+          NP2Loader.fetchFile("Disk Image",
+            "examples/np2/FreeDOS(98)_5M.NHD")),
+        NP2Loader.mountFile("np2.cfg",
+          NP2Loader.fetchFile("Configuration file",
+            "examples/np2/np2.cfg")),
+      ));
+    emulator.setScale(3).start({ waitAfterDownloading: true });
+  </script>
+</body>
+
+</html>

--- a/example_xmil.html
+++ b/example_xmil.html
@@ -1,0 +1,61 @@
+<!--
+ The Emularity: An Example Computer Loader
+ For use with The Emularity, downloadable at http://www.emularity.com/
+
+ SIMPLE STEPS for trying an emulated computer ("Gradius" for the
+ Sharp X1 Turbo).
+
+ * Check out this repository in your browser-accessible directory;
+   this file as well as es6-promise.js, browserfs.min.js and loader.js
+   are required. The logo and images directories are optional, but the
+   splash screen looks quite a lot better when they're available.
+
+ * Download the Neko Project II emulator from
+   https://yksoft1.github.io/emularity/xmil/xmil.js
+   https://yksoft1.github.io/emularity/xmil/xmil.wasm
+
+ * Download BIOS and configuration from
+   http://9game.oss-us-west-1.aliyuncs.com/np2/sharp-x1turbo-rom.zip
+
+ * Download the Gradius disk image from:
+   http://9game.oss-us-west-1.aliyuncs.com/np2/Gradius.2d
+
+ * Place BIOS, configuration file and disk image in an
+   "examples/np2" subdirectory.
+
+ * Visit your example_computer.html file with a modern
+   Javascript-capable browser.
+-->
+
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>example computer program</title>
+</head>
+
+<body>
+  <canvas id="canvas" style="width: 50%; height: 50%; display: block; margin: 0 auto;" />
+  <script type="text/javascript" src="es6-promise.js"></script>
+  <script type="text/javascript" src="browserfs.min.js"></script>
+  <script type="text/javascript" src="loader.js"></script>
+  <script type="text/javascript">
+    var emulator = new Emulator(document.querySelector("#canvas"),
+      null,
+      new NP2Loader(
+        NP2Loader.nativeResolution(320, 200),
+        NP2Loader.emulatorJS("emulators/xmil.js"),
+        NP2Loader.emulatorWASM("emulators/xmil.wasm"),
+        NP2Loader.mountZip("xmil-em",
+          NP2Loader.fetchFile("BIOS",
+            "examples/np2/sharp-x1turbo-rom.zip")),
+        NP2Loader.mountFile("Gradius.2d",
+          NP2Loader.fetchFile("Disk Image",
+            "examples/np2/Gradius.2d")),
+        NP2Loader.extraArgs(["/emulator/Gradius.2d"])
+      ));
+    emulator.setScale(3).start({ waitAfterDownloading: true });
+  </script>
+</body>
+
+</html>

--- a/loader.js
+++ b/loader.js
@@ -735,6 +735,24 @@ var Module = null;
      return { extra_pce_args: args };
    };
 
+   /**
+   * NP2Loader
+   */
+  function NP2Loader() {
+    var config = Array.prototype.reduce.call(arguments, extend);
+    config.emulator_arguments = build_np2_arguments(config.emulatorStart, config.files, config.extra_np2_args);
+    config.runner = NP2Runner;
+    return config;
+  }
+  NP2Loader.__proto__ = BaseLoader;
+  
+  NP2Loader.autoLoad = function (path) {
+    return { emulatorStart: path };
+  };
+  NP2Loader.extraArgs = function (args) {
+    return { extra_np2_args: args };
+  }
+
    var build_mame_arguments = function (muted, driver, native_resolution, sample_rate, peripheral, extra_args, keepaspect) {
      var args = [driver,
                  '-verbose',
@@ -811,6 +829,14 @@ var Module = null;
      }
      return args;
    };
+
+   var build_np2_arguments = function (emulator_start, files, extra_args) {
+    var args = emulator_start ? [emulator_start] : [];
+    if (extra_args) {
+     args = args.concat(extra_args);
+    }
+    return args;
+  }
 
    /*
     * EmscriptenRunner
@@ -905,6 +931,23 @@ var Module = null;
     FS.symlink('/emulator/y/2608_tom.wav', '/2608_tom.wav');
     FS.symlink('/emulator/y/2608_top.wav', '/2608_top.wav');
   }
+
+   /*
+   * NP2Runner
+   */
+   function NP2Runner() {
+     return EmscriptenRunner.apply(this, arguments);
+   }
+   NP2Runner.prototype = Object.create(EmscriptenRunner.prototype);
+   NP2Runner.prototype.start = function () {
+     try {
+      var configFile = FS.readFile('/emulator/np2.cfg');
+      FS.writeFile('/emulator/np2/np2.cfg', configFile);
+     } catch (ex) {
+      //If the user config file not found, NP2 will use default settings
+      console.log(ex)
+     }
+   }
 
    /*
     * MAMERunner
@@ -1903,6 +1946,7 @@ var Module = null;
    window.SAELoader = SAELoader;
    window.PCELoader = PCELoader;
    window.VICELoader = VICELoader;
+   window.NP2Loader = NP2Loader;
    window.Emulator = Emulator;
    window._SDL_CreateRGBSurfaceFrom = _SDL_CreateRGBSurfaceFrom;
  })(typeof Promise === 'undefined' ? ES6Promise.Promise : Promise);


### PR DESCRIPTION
yksoft1 has ported Neko Project II (PC-98 emulator) and X Millennium (Sharp X1 emulator) to Emscripten and they can work with Emularity with a very simple NP2Loader
Here is yksoft1's original page: https://yksoft1.github.io/