### PR TITLE
Write emulator files to MountableFS not OverlayFS

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1543,12 +1543,12 @@ var Module = null;
                                                            var parts = filename.split('/');
                                                            for (var i = 1; i < parts.length; i++) {
                                                              var path = '/'+ parts.slice(0, i).join('/');
-                                                             if (!game_data.fs.existsSync(path)) {
-                                                               game_data.fs.mkdirSync(path);
+                                                             if (!mountable.existsSync(path)) {
+                                                               mountable.mkdirSync(path);
                                                              }
                                                            }
                                                          }
-                                                         game_data.fs.writeFileSync('/'+ filename, new Buffer(data), null, flag_w, 0x1a4);
+                                                         mountable.writeFileSync('/'+ filename, new Buffer(data), null, flag_w, 0x1a4);
                                                        }
                                                      };
                                                    }


### PR DESCRIPTION
Up until now, during emulator setup the loader has been writing emulator .zip, .cfg, .chd, etc. files into the OverlayFS which persists to IndexedDB, when the intent of the OverlayFS was really just to capture any writes that the emulator makes at runtime.  This has been polluting the IndexedDB with a bunch of potentially large files which end up being redownloaded anyway.

There's a potential argument for keeping things as they are and checking to see if the files are in the OverlayFS before downloading, which would make reloads of systems with large data files instantaneous, but as it stands now this is triggering another issue where some files/directories created on the OverlayFS during setup end up with an invalid mode, which is causing the emulator to bail out when loading CHD files.

This fix should work around that issue, but it's potentially worth revisiting the "cache to IndexedDB" functionality if there ends up being a BrowserFS bug about modes being set incorrectly on the OverlayFS that gets fixed.