### PR TITLE
fix: don't double-load chd files for chd-based items

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -388,7 +388,8 @@ var Module = null;
 
      function get_mame_files(cfgr, metadata, modulecfg, filelist) {
        var files = [],
-           bios_files = modulecfg['bios_filenames'];
+           bios_files = modulecfg['bios_filenames'],
+           already_fetched_urls = [];
        bios_files.forEach(function (fname, i) {
                             if (fname) {
                               var title = "Bios File ("+ (i+1) +" of "+ bios_files.length +")";
@@ -421,6 +422,7 @@ var Module = null;
                                                                : get_zip_url(filename, get_item_name(game));
                             files.push(cfgr.mountFile('/'+ filename,
                                                       cfgr.fetchFile(title, url)));
+                            already_fetched_urls.push(url);
                           });
 
        // add on game drive (.chd) files, if any
@@ -431,8 +433,10 @@ var Module = null;
                              var title = "Game Drive ("+ (i+1) +" of "+ len +")";
                              var url = (file.name.includes("/")) ? get_zip_url(file.name)
                                                                  : get_zip_url(file.name, get_item_name(game));
-                             files.push(cfgr.mountFile(modulecfg.driver + '/' + file.name,
-                                                       cfgr.fetchFile(title, url)));
+                             if (!already_fetched_urls.includes(url)) {
+                               files.push(cfgr.mountFile(modulecfg.driver + '/' + file.name,
+                                                         cfgr.fetchFile(title, url)));
+                             }
                            });
 
        Object.keys(peripherals).forEach(function (periph) {

--- a/loader.js
+++ b/loader.js
@@ -393,9 +393,10 @@ var Module = null;
        bios_files.forEach(function (fname, i) {
                             if (fname) {
                               var title = "Bios File ("+ (i+1) +" of "+ bios_files.length +")";
+                              var url = get_bios_url(fname);
                               files.push(cfgr.mountFile('/'+ fname,
-                                                        cfgr.fetchFile(title,
-                                                                       get_bios_url(fname))));
+                                                        cfgr.fetchFile(title, url)));
+                              already_fetched_urls.push(url);
                             }
                           });
 


### PR DESCRIPTION
If `emulator_ext` is `chd`, we pull .chd files for the game files and then again as drive files. (For example, this happens on psx items, such as https://archive.org/details/net_yaroze_2019.)

It appears as though the drive files aren't necessary in that case. This change prevents us from pulling the .chd files twice, speeding up the loading.

It's possible there is a better way to identify which files are game files versus which are drive files, possibly via an optional `drive_ext` meta setting as identified in the existing comment, but this seems to work in practice for a couple test psx items. Happy to rewrite if there are other preferences.